### PR TITLE
adds option to passthru stdout/stderr to controlling tty

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Application Options:
       --log-path=                  where to place the log files for command output (path for -F/--log-fail output) (/var/log/cronner)
   -L, --log-level=                 set the level at which to log at [none|error|info|debug] (error)
   -N, --namespace=                 namespace for statsd emissions, value is prepended to metric name by statsd client (cronner)
+  -p, --passthru                   passthru stdout/stderr to controlling tty
   -s, --sensitive                  specify whether command output may contain sensitive details, this only avoids it being printed to stderr (false)
   -V, --version                    print the version string and exit
   -w, --warn-after=N               emit a warning event every N seconds if the job hasn't finished, set to 0 to disable (0)

--- a/args.go
+++ b/args.go
@@ -20,16 +20,17 @@ type binArgs struct {
 	Cmd         string   // this is not a command line flag, but rather parsed results
 	CmdArgs     []string // this is not a command line flag, also parsed results
 	LockDir     string   `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
-	AllEvents   bool     `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
-	FailEvent   bool     `short:"E" long:"event-fail" default:"false" description:"only emit an event on failure"`
-	LogFail     bool     `short:"F" long:"log-fail" default:"false" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
+	AllEvents   bool     `short:"e" long:"event" description:"emit a start and end datadog event"`
+	FailEvent   bool     `short:"E" long:"event-fail" description:"only emit an event on failure"`
+	LogFail     bool     `short:"F" long:"log-fail" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
 	EventGroup  string   `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
-	Lock        bool     `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
+	Lock        bool     `short:"k" long:"lock" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
 	Label       string   `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
 	LogPath     string   `long:"log-path" default:"/var/log/cronner" description:"where to place the log files for command output (path for -F/--log-fail output)"`
 	LogLevel    string   `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
 	Namespace   string   `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
-	Sensitive   bool     `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
+	Passthru    bool     `short:"p" long:"passthru" description:"passthru stdout/stderr to controlling tty"`
+	Sensitive   bool     `short:"s" long:"sensitive" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
 	Version     bool     `short:"V" long:"version" description:"print the version string and exit"`
 	WarnAfter   uint64   `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
 	WaitSeconds uint64   `short:"W" long:"wait-secs" default:"0" description:"how long to wait for the file lock for"`

--- a/args_test.go
+++ b/args_test.go
@@ -104,6 +104,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.LogPath, Equals, "/var/log/cronner")
 	c.Check(args.LogLevel, Equals, "error")
 	c.Check(args.Namespace, Equals, "cronner")
+	c.Check(args.Passthru, Equals, false)
 	c.Check(args.Sensitive, Equals, false)
 	c.Check(args.Version, Equals, false)
 	c.Check(args.WarnAfter, Equals, uint64(0))
@@ -124,6 +125,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"-l", "test",
 		"-L", "info",
 		"-N", "testcronner",
+		"-p",
 		"-s",
 		"-w", "42",
 		"-W", "84",
@@ -147,6 +149,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.Label, Equals, "test")
 	c.Check(args.LogLevel, Equals, "info")
 	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.Passthru, Equals, true)
 	c.Check(args.Sensitive, Equals, true)
 	c.Check(args.Version, Equals, false)
 	c.Check(args.WarnAfter, Equals, uint64(42))
@@ -170,6 +173,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 		"--log-path", "/var/log/testcronner",
 		"--log-level", "info",
 		"--namespace", "testcronner",
+		"--passthru",
 		"--sensitive",
 		"--warn-after", "42",
 		"--wait-secs", "84",
@@ -191,6 +195,7 @@ func (t *TestSuite) Test_binArgs_parse(c *C) {
 	c.Check(args.LogPath, Equals, "/var/log/testcronner")
 	c.Check(args.LogLevel, Equals, "info")
 	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.Passthru, Equals, true)
 	c.Check(args.Sensitive, Equals, true)
 	c.Check(args.Version, Equals, false)
 	c.Check(args.WarnAfter, Equals, uint64(42))

--- a/cronner.go
+++ b/cronner.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.2.5"
+const Version = "0.2.6"
 
 type cmdHandler struct {
 	gs       *godspeed.Godspeed

--- a/runner_test.go
+++ b/runner_test.go
@@ -409,7 +409,6 @@ func (t *TestSuite) Test_handleCommand(c *C) {
 
 	t.h.cmd = exec.Command("/bin/bash", "testdata/echo.sh")
 	t.h.opts.Passthru = true
-	t.h.opts.AllEvents = true
 
 	// Capture stdout/stderr
 	oldStdout := os.Stdout
@@ -454,7 +453,7 @@ func (t *TestSuite) Test_handleCommand(c *C) {
 	// Check the output
 	c.Assert(err, IsNil)
 	c.Check(retCode, Equals, 0)
-	c.Assert(string(r), Equals, "stdout\nstderr\nstderr\nstdout\nstderr\nstdout\nstdout\nstderr\n")
+	c.Assert(len(r), Equals, 0)
 	c.Assert(stdout, Equals, "stdout\nstdout\nstdout\nstdout\n")
 	c.Assert(stderr, Equals, "stderr\nstderr\nstderr\nstderr\n")
 

--- a/testdata/echo.sh
+++ b/testdata/echo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "stdout"
+(>&2 echo "stderr")
+(>&2 echo "stderr")
+echo "stdout"
+(>&2 echo "stderr")
+echo "stdout"
+echo "stdout"
+(>&2 echo "stderr")


### PR DESCRIPTION
Adds new option to allow passthrough to TTY. Removes `default:"false"` from CLI setup, which throws an error.
